### PR TITLE
Bugfix for the extended payload

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -56,18 +56,8 @@ window.scrNoti.messageOnUpdatedListener = async (
   }
 
   if (changedProperties.read) {
-    // We keep the message id in the seenMessages until we delete the message,
-    // so that the message does not show up again as new
+    seenMessages[message.folder.accountId + message.folder.path].delete(message.id);
     await window.scrNoti.notifyNativeScript(message, "read");
-  } else {
-    const { scriptType } = await messenger.storage.local.get({
-      scriptType: "simple",
-    });
-    if (scriptType != "simple") {
-      // We add the message id to the seenMessages, because we do not want this
-      // message to show up again as new
-      seenMessages[message.folder.accountId + message.folder.path].add(message.id);
-    }
   }
 };
 browser.messages.onUpdated.removeListener(

--- a/src/background.js
+++ b/src/background.js
@@ -56,7 +56,12 @@ window.scrNoti.messageOnUpdatedListener = async (
   }
 
   if (changedProperties.read) {
-    seenMessages[message.folder.accountId + message.folder.path].delete(message.id);
+    const { scriptType } = await messenger.storage.local.get({
+      scriptType: "simple",
+    });
+    if (scriptType == "extended") {
+      seenMessages[message.folder.accountId + message.folder.path].delete(message.id);
+    }
     await window.scrNoti.notifyNativeScript(message, "read");
   }
 };

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -225,14 +225,16 @@ const sendTestToScript = async (event) => {
        "path": "/INBOX",
        "totalMessageCount": 74,
        "type": "inbox",
-       "unreadMessageCount": 7},
+       "unreadMessageCount": 7,
+       "seenMessageCount": 7},
       {"accountId": "account3",
        "favorite": true,
        "name": "Inbox",
        "path": "/INBOX",
        "totalMessageCount": 94,
        "type": "inbox",
-       "unreadMessageCount": 3}],
+       "unreadMessageCount": 3,
+       "seenMessageCount": 3}],
     "event": event,
     "message": {
       "author": "Someone Else <some.one.else@nowhere.org>",
@@ -256,8 +258,21 @@ const sendTestToScript = async (event) => {
     };
   switch (event) {
     case "start":
+      // Set message to null
       payload.message = null;
+      await browser.runtime.sendNativeMessage(
+        "scriptableNotifications",
+        payload
+      );
+      break
     case "new":
+      // Changes 'seenMessageCount'
+      payload.folders.at(1).seenMessageCount = payload.folders.at(1).unreadMessageCount - 1;
+      await browser.runtime.sendNativeMessage(
+        "scriptableNotifications",
+        payload
+      );
+      break
     case "read":
       await browser.runtime.sendNativeMessage(
         "scriptableNotifications",

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -259,7 +259,6 @@ const sendTestToScript = async (event) => {
       payload.message = null;
     case "new":
     case "read":
-    case "deleted":
       await browser.runtime.sendNativeMessage(
         "scriptableNotifications",
         payload


### PR DESCRIPTION
Fixes 3 bugs:
1. Removes the "deleted" branch in `sendTestToScript()`.
2. Adds the `seenMessageCount` to the testing payload.
3. Fixes the bookkeeping of the `seenMessages`.