### PR TITLE
Connection based messaging. (Closes #8)

### DIFF
--- a/scriptExamples/extendedMode/python-logging/script-connection-based.py
+++ b/scriptExamples/extendedMode/python-logging/script-connection-based.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """
-Script to debug the "Scriptable Notifications" add-on for Thunderbird.
+Script to debug the connection based mode of the "Scriptable Notifications"
+add-on for Thunderbird.
 
 This script receives the extended message from the add-on and writes it to a
 log file in the user's home directory. The file has the same basename as this

--- a/scriptExamples/extendedMode/python-logging/script-connection-based.py
+++ b/scriptExamples/extendedMode/python-logging/script-connection-based.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""
+Script to debug the "Scriptable Notifications" add-on for Thunderbird.
+
+This script receives the extended message from the add-on and writes it to a
+log file in the user's home directory. The file has the same basename as this
+script, but the suffix ".log".
+
+MIT License
+Copyright (C) 2022  Stephan Helma
+
+"""
+
+import json
+import pathlib
+import pprint
+import struct
+import sys
+import time
+import traceback
+
+
+LOGFILE = pathlib.Path(
+    '~', pathlib.Path(__file__).with_suffix('.log').name
+    ).expanduser()
+
+
+#
+# Helper functions
+#
+
+def get_message(buf):
+    """Get message from the standard input."""
+    raw_length = buf.read(4)
+    if len(raw_length) == 0:
+        return {}
+    length = struct.unpack('@I', raw_length)[0]
+    message = buf.read(length).decode('utf-8')
+    return message
+
+
+def send_message(msg):
+    """Send message to the standard output."""
+    content = f'"{msg}"'.encode('utf-8')
+    length = struct.pack('@I', len(content))
+    sys.stdout.buffer.write(length)
+    sys.stdout.buffer.write(content)
+    sys.stdout.buffer.flush()
+
+#
+# Main function
+#
+
+def main():
+    with open(LOGFILE, 'a') as log:
+        with sys.stdin.buffer as buf:
+            print(f'****** stdin opened ******', file=log')
+            try:
+                # Get message sent
+                message = get_message(buf)
+
+                # Parse the message
+                payload = json.loads(message)
+
+                # (Pretty) print to logfile
+                print(f'====== {time.asctime()} ======', file=log)
+                pp = pprint.PrettyPrinter(stream=log)
+                pp.pprint(payload)
+
+                # Send back required message
+                send_message({})
+
+            except Exception as e:
+                # If anything goes wrong, write the traceback to the logfile
+                print(
+                    f'EXCEPTION: '
+                    f'{"".join(traceback.format_exception(type(e), e, e.__traceback__))}',
+                    file=log)
+
+        print(f'====== {time.asctime()} ======', file=log)
+        print(f'****** stdin closed ******', file=log')
+
+
+if __name__ == '__main__':
+    main()

--- a/scriptExamples/extendedMode/python-logging/script-connectionless.py
+++ b/scriptExamples/extendedMode/python-logging/script-connectionless.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """
-Script to debug the "Scriptable Notifications" add-on for Thunderbird.
+Script to debug the connectionless mode of the "Scriptable Notifications"
+add-on for Thunderbird.
 
 This script receives the extended message from the add-on and writes it to a
 log file in the user's home directory. The file has the same basename as this

--- a/src/background.js
+++ b/src/background.js
@@ -4,7 +4,7 @@
 
 window.scrNoti = window.scrNoti || {};
 const seenMessages = {};
-let port = null;
+let nativeConnection = null;
 
 //==========================================
 // On new email...
@@ -76,9 +76,9 @@ browser.messages.onUpdated.addListener(window.scrNoti.messageOnUpdatedListener);
 //==========================================
 window.scrNoti.onNotifyListener = async (message) => {
   if ("optionsChanged" in message && message.optionsChanged) {
-    if (port != null) {
-      port.disconnect();
-      port = null;
+    if (nativeConnection != null) {
+      nativeConnection.disconnect();
+      nativeConnection = null;
     };
     await window.scrNoti.updateSeenMessages();
     await window.scrNoti.notifyNativeScript(null, "start");
@@ -232,10 +232,11 @@ window.scrNoti.notifyNativeScript = async (message, event) => {
       );
       break;
     case "connectionbased":
-      if (port == null) {
-        port = await browser.runtime.connectNative("scriptableNotifications");
+      if (nativeConnection == null) {
+        nativeConnection = await browser.runtime.connectNative(
+          "scriptableNotifications");
       };
-      await port.postMessage(payload);
+      await nativeConnection.postMessage(payload);
       break;
   };
 

--- a/src/background.js
+++ b/src/background.js
@@ -4,6 +4,7 @@
 
 window.scrNoti = window.scrNoti || {};
 const seenMessages = {};
+let port = null;
 
 //==========================================
 // On new email...
@@ -75,7 +76,12 @@ browser.messages.onUpdated.addListener(window.scrNoti.messageOnUpdatedListener);
 //==========================================
 window.scrNoti.onNotifyListener = async (message) => {
   if ("optionsChanged" in message && message.optionsChanged) {
-    window.scrNoti.updateSeenMessages();
+    if (port != null) {
+      port.disconnect();
+      port = null;
+    };
+    await window.scrNoti.updateSeenMessages();
+    await window.scrNoti.notifyNativeScript(null, "start");
   }
 };
 browser.runtime.onMessage.removeListener(
@@ -214,10 +220,25 @@ window.scrNoti.notifyNativeScript = async (message, event) => {
       break;
   };
 
-  await browser.runtime.sendNativeMessage(
-    "scriptableNotifications",
-    payload
-  );
+  const { connectionType } = await messenger.storage.local.get({
+    connectionType: "connectionless",
+  });
+
+  switch (connectionType) {
+    case "connectionless":
+      await browser.runtime.sendNativeMessage(
+        "scriptableNotifications",
+        payload
+      );
+      break;
+    case "connectionbased":
+      if (port == null) {
+        port = await browser.runtime.connectNative("scriptableNotifications");
+      };
+      await port.postMessage(payload);
+      break;
+  };
+
 };
 
 //==========================================

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -140,7 +140,7 @@
               <label for="notifyConnectionConnectionless">
                 <strong>Connectionless</strong>
                 <br/>
-                A new instance of the native appliation is created for each message.
+                A new instance of the native script/application is created for each message.
               </label>
             </p>
             <p>
@@ -148,8 +148,8 @@
               <label for="notifyConnectionConnectionbased">
                 <strong>Connection based</strong>
                 <br/>
-                This launches the native application, if it is not already running.
-                The application stays running until Thunderbird is closed.
+                This launches the native script/application, if it is not already running.
+                The script/application stays running until Thunderbird is closed.
               </label>
             </p>
           </div>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -146,7 +146,7 @@
             <p>
               <input type="radio" id="notifyConnectionConnectionbased" name="notifyConnection" value="connectionbased">
               <label for="notifyConnectionConnectionbased">
-                <strong>Extended</strong>
+                <strong>Connection based</strong>
                 <br/>
                 This launches the native application, if it is not already running.
                 The application stays running until Thunderbird is closed.

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -93,7 +93,7 @@
         </div>
       </p>
       <p>
-        <div class="sectionTitle">Select type of data sent to the native script</div>
+        <div class="sectionTitle">Type of data sent to the native script</div>
         <p>
           <div>
             <p>
@@ -127,6 +127,30 @@
               <button type="button" class="smallBtn" id="notifyScriptStart">Start Thunderbird</button>
               <button type="button" class="smallBtn" id="notifyScriptNew">New message</button>
               <button type="button" class="smallBtn" id="notifyScriptRead">Message read</button>
+            </p>
+          </div>
+        </p>
+      </p>
+      <p>
+        <div class="sectionTitle">Type of data connection</div>
+        <p>
+          <div>
+            <p>
+              <input type="radio" id="notifyConnectionConnectionless" name="notifyConnection" value="connectionless" checked="checked">
+              <label for="notifyConnectionConnectionless">
+                <strong>Connectionless</strong>
+                <br/>
+                A new instance of the native appliation is created for each message.
+              </label>
+            </p>
+            <p>
+              <input type="radio" id="notifyConnectionConnectionbased" name="notifyConnection" value="connectionbased">
+              <label for="notifyConnectionConnectionbased">
+                <strong>Extended</strong>
+                <br/>
+                This launches the native application, if it is not already running.
+                The application stays running until Thunderbird is closed.
+              </label>
             </p>
           </div>
         </p>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -313,9 +313,13 @@ const saveOptions = async () => {
   // "simple" or "extended"
   const scriptType = document.querySelector('input[name="notifyScriptType"]:checked').value;
 
+  // "connectionless" or "connectionbased"
+  const connectionType = document.querySelector('input[name="notifyConnection"]:checked').value;
+
   await messenger.storage.local.set({
     foldersToCheck: foldersToCheck,
     scriptType: scriptType,
+    connectionType: connectionType,
   });
   // Update `seenMessages` dictionary
   await browser.runtime.sendMessage({optionsChanged: true});
@@ -387,6 +391,19 @@ const restoreOptions = async () => {
       document.getElementById("notifyScriptStart").disabled = false;
       document.getElementById("notifyScriptNew").disabled = false;
       document.getElementById("notifyScriptRead").disabled = false;
+      break;
+  };
+
+  const { connectionType } = await messenger.storage.local.get({
+    connectionType: "connectionless",
+  });
+
+  switch (connectionType) {
+    case "connectionless":
+      document.getElementById("notifyConnectionConnectionless").checked = true;
+      break;
+    case "connectionbased":
+      document.getElementById("notifyConnectionConnectionbased").checked = true;
       break;
   };
 


### PR DESCRIPTION
This implements a connection based messaging as outlined in https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging#connection-based_messaging.

With this approach,
- the native scripts runs permanently, receiving the payload over the standard input.
- the native scripts gets notified, when Thunderbird closes (by receiving a `SIGTERM` signal.
- the overhead of starting the native script is removed.

This feature can be switched on/off in the configuration screen.

There is also a Python test script similar to that one for the extended mode.

My motivation was: I run an icon in the system tray which shows the number of unread messages and can call Thunderbird. For this I need a long-running server. With the "old" approach, I had to start the server and pass the payload from the native script to this server. (And could not close the server, when Thunderbird was closed.) With the connection based messaging, the native script _is_ the server – no starting of the server, no passing around of the payload; just listening on the standard input for new messages!