### PR TITLE
Add macOS working example, fix options page

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ another notification solution where you don't have to write an external script.
 
 #### Warning
 
-Some people with a Mac say they cannot get the addon to work. If anyone with a Mac is able to get the addon to work, please let me know if there's anything special you need to do to get it to work, and I'll update the documentation...
-
 Note that the add-on will not work with a _Snap_ or _Flatpak_ version of Thunderbird. Those
 currently don't seem to support Native Messaging at all!
 If you know how to fix this, please let me know.
@@ -86,7 +84,7 @@ On the "options" page of the add-on:
 
   2. Register your script. Registering the script is required because WebExtentions (the
      new way of writing add-ons for Thunderbird, Firefox, Chrome, etc.) are picky
-     on how an add-on can run a native executable. The protocole used is called
+     on how an add-on can run a native executable. The protocol used is called
      [Native messaging](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging).
 
      The instructions on how to register your script are provided for Linux/Mac and Windows.
@@ -182,6 +180,14 @@ Python 3 must be installed on the Windows machine.
 The `scriptExamples/simpleMode/windows-simple/simpleNotification.py` file must
 be kept in the same directory as the `script.bat`.
 
+**Mac - Simple**
+
+Provided at: `scriptExamples/simpleMode/mac-simple/simpleNotification.py`.
+
+Very basic script, only displays small alert messages.
+
+Python 3 must be installed.
+
 **Linux - Simple**
 
 Provided at: `scriptExamples/simpleMode/linux-simple/script.sh`.
@@ -207,12 +213,12 @@ able to add the icon to the system tray.
 
 The `scriptExamples/simpleMode/linux-kde-sound-tray/showThunderbirdTrayIcon.py` and
 `scriptExamples/simpleMode/linux-kde-sound-tray/tada.wav` files must be kept in the
-same directory as the`script.sh` script.
+same directory as the `script.sh` script.
 
 ### Writing an external script
 
 - It is a good idea to start your script from one provided in the
-  `scriptExamples` folder because the `Native messaging` protocole expects your
+  `scriptExamples` folder because the `Native messaging` protocol expects your
   script to read and write some data in a specific way.
 
 - There are some extra tips on how to write a native script on this

--- a/scriptExamples/simpleMode/mac-simple/simpleNotification.py
+++ b/scriptExamples/simpleMode/mac-simple/simpleNotification.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# This is a basic example of a macOS script implementation for
+# the "Scriptable Notifications" Thunderbird add-on.
+#
+# it provides the utility functions required to properly get the
+# "hasUnreadMessages" parameter from the add-on, and
+# to close the connection properly.
+#
+# All you have to do to change the "main()" function.
+#
+# Make sure it is executable and that the shebang at the top
+# points to your copy of Python.
+#
+import sys
+import json
+import struct
+import subprocess
+import shlex
+
+#==========================================
+# Main function
+#==========================================
+def main(hasUnreadMessages):
+    if hasUnreadMessages:
+        msg = "✮✮✮ New mails to read! ✮✮✮"
+    else:
+        msg = "All mail read."
+
+    showAlert(msg)
+
+#==========================================
+# Utility functions.
+# Work with Python 3.
+#
+# From:
+# - https://github.com/mdn/webextensions-examples/blob/master/native-messaging/app/ping_pong.py
+#==========================================
+# Show the message using AppleScript
+def showAlert(msg):
+    subprocess.run(shlex.split('''
+        osascript -e 'display notification \"{}\" with title \"Scriptable Notifications\"'
+    '''.format(msg)))
+
+# Read a message from stdin and decode it.
+def getMessage():
+    rawLength = sys.stdin.buffer.read(4)
+    if len(rawLength) == 0:
+        sys.exit(0)
+    messageLength = struct.unpack('@I', rawLength)[0]
+    message = sys.stdin.buffer.read(messageLength).decode('utf-8')
+    return json.loads(message)
+
+# Encode a message for transmission,
+# given its content.
+def encodeMessage(messageContent):
+    encodedContent = json.dumps(messageContent).encode('utf-8')
+    encodedLength = struct.pack('@I', len(encodedContent))
+    return {'length': encodedLength, 'content': encodedContent}
+
+# Send an encoded message to stdout
+def sendMessage(encodedMessage):
+    sys.stdout.buffer.write(encodedMessage['length'])
+    sys.stdout.buffer.write(encodedMessage['content'])
+    sys.stdout.buffer.flush()
+
+
+#==========================================
+# Get the "true" or "false" parameter from the add-on, call the
+# "main()" function and close the connection properly.
+#==========================================
+hasUnreadMessages = getMessage()
+main(hasUnreadMessages)
+sendMessage(encodeMessage("{}"))

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -69,7 +69,7 @@
           <div id="registerTabContentMac" class="registerTabContent">
             <p>
               Download the resulting manifest and save it to:
-              <code>~/Library/Application Support/Mozilla/NativeMessagingHosts/scriptableNotifications.json</code>.
+              <code>~/Library/Mozilla/NativeMessagingHosts/scriptableNotifications.json</code>.
               Create the parent directories if required.
             </p>
             <p>
@@ -159,7 +159,7 @@
         <div class="sectionTitle">Mail/Feed folders to monitor</div>
         <div>
           <div id="accountsTip">
-            <em>Tip</em>: To include a mail folder in this list that is not a default <em>inbox</em>, 
+            <em>Tip</em>: To include a mail folder in this list that is not a default <em>inbox</em>,
             mark it as "Favorite Folder" (right click it).
           </div>
           <ul id="accounts"></ul>


### PR DESCRIPTION
Adds a working macOS example script (based on the Windows script) to the scriptExamples folder and a description in the README.

Fixes the instructions on the options page for where to save the manifest.

Fixes typos in the README.

Closes #14 