### PR TITLE
Fix test payload for the extended mode

### DIFF
--- a/src/options/options.js
+++ b/src/options/options.js
@@ -222,31 +222,31 @@ const addListeners = async () => {
 //==========================================
 const sendTestToScript = async (event) => {
   const payload = {
-    "accounts": [
-      {"id": "account1",
-       "identities": [],
-       "name": "Local Folders",
-       "type": "none"},
-      {"id": "account2",
-       "identities": [
-          {"email": "name.surname@company.com",
-           "label": "",
-           "name": "Name Surname",
-           "organization": "Company"}],
-       "name": "Business",
-       "type": "imap"},
-      {"id": "account3",
-       "identities": [
-          {"email": "name@private.net",
-           "label": "",
-           "name": "Name Surname",
-           "organization": ""},
-          {"email": "name.surname@private.net",
-           "label": "",
-           "name": "Name Surname",
-           "organization": ""}],
-       "name": "Private",
-       "type": "imap"}],
+    "accounts": {
+      "account1": {
+        "identities": [],
+        "name": "Local Folders",
+        "type": "none"},
+      "account2": {
+        "identities": [
+           {"email": "name.surname@company.com",
+            "label": "",
+            "name": "Name Surname",
+            "organization": "Company"}],
+        "name": "Business",
+        "type": "imap"},
+      "account3": {
+        "identities": [
+           {"email": "name@private.net",
+            "label": "",
+            "name": "Name Surname",
+            "organization": ""},
+           {"email": "name.surname@private.net",
+            "label": "",
+            "name": "Name Surname",
+            "organization": ""}],
+        "name": "Private",
+        "type": "imap"}},
     "folders": [
       {"accountId": "account2",
        "favorite": true,


### PR DESCRIPTION
First of all, thank you for creating this addon! It’s exactly what I was looking for and works perfectly for my needs.

I noticed a minor discrepancy in the payload structure between real events and test events from the options page, so I adjusted the test payload to match real events:

---

In real payloads generated by window.scrNoti.notifyNativeScript, the "accounts" field carries an object, not an array.